### PR TITLE
Migrating carbon and phpdotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=7.1.3",
         "illuminate/database": "~5.6",
         "illuminate/support": "~5.6",
-        "nesbot/carbon": "~1.0",
+        "nesbot/carbon": "~2.0",
         "symfony/http-kernel": "~2.7|~3.0|~4.0",
         "guzzlehttp/guzzle": "^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/routing": "~5.6",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~7.0",
-        "vlucas/phpdotenv": "~2.0",
+        "vlucas/phpdotenv": "^3.3",
         "orchestra/testbench": "~3.6"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -16,7 +16,9 @@ class WebhookController extends Controller
     /**
      * Handle a Fastspring webhook call.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request $request The webhook requet
+     *
+     * @throws Exception
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
@@ -71,32 +73,38 @@ class WebhookController extends Controller
                 }
 
                 // trigger events
-                Event::fire(new Events\Any(
-                    $event['id'],
-                    $event['type'],
-                    $event['live'],
-                    $event['processed'],
-                    $event['created'],
-                    $event['data']
-                ));
+                Event::dispatch(
+                    new Events\Any(
+                        $event['id'],
+                        $event['type'],
+                        $event['live'],
+                        $event['processed'],
+                        $event['created'],
+                        $event['data']
+                    )
+                );
 
-                Event::fire(new $categoryEvent(
-                    $event['id'],
-                    $event['type'],
-                    $event['live'],
-                    $event['processed'],
-                    $event['created'],
-                    $event['data']
-                ));
+                Event::dispatch(
+                    new $categoryEvent(
+                        $event['id'],
+                        $event['type'],
+                        $event['live'],
+                        $event['processed'],
+                        $event['created'],
+                        $event['data']
+                    )
+                );
 
-                Event::fire(new $activityEvent(
-                    $event['id'],
-                    $event['type'],
-                    $event['live'],
-                    $event['processed'],
-                    $event['created'],
-                    $event['data']
-                ));
+                Event::dispatch(
+                    new $activityEvent(
+                        $event['id'],
+                        $event['type'],
+                        $event['live'],
+                        $event['processed'],
+                        $event['created'],
+                        $event['data']
+                    )
+                );
 
                 // add event id to successful events
                 $successfulEvents[] = $event['id'];

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
 use Log;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -55,11 +56,11 @@ class WebhookController extends Controller
             // prepare category event class names like OrderAny
             $explodedType = explode('.', $event['type']);
             $category = array_shift($explodedType);
-            $categoryEvent = '\Bgultekin\CashierFastspring\Events\\'.studly($category).'Any';
+            $categoryEvent = '\Bgultekin\CashierFastspring\Events\\'.Str::studly($category).'Any';
 
             // prepare category event class names like activity
             $activity = str_replace('.', ' ', $event['type']);
-            $activityEvent = '\Bgultekin\CashierFastspring\Events\\'.studly($activity);
+            $activityEvent = '\Bgultekin\CashierFastspring\Events\\'.Str::studly($activity);
 
             // there may be some exceptions on events
             // so if anything goes bad its ID won't be added on the successfullEvents

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -55,11 +55,11 @@ class WebhookController extends Controller
             // prepare category event class names like OrderAny
             $explodedType = explode('.', $event['type']);
             $category = array_shift($explodedType);
-            $categoryEvent = '\Bgultekin\CashierFastspring\Events\\'.studly_case($category).'Any';
+            $categoryEvent = '\Bgultekin\CashierFastspring\Events\\'.studly($category).'Any';
 
             // prepare category event class names like activity
             $activity = str_replace('.', ' ', $event['type']);
-            $activityEvent = '\Bgultekin\CashierFastspring\Events\\'.studly_case($activity);
+            $activityEvent = '\Bgultekin\CashierFastspring\Events\\'.studly($activity);
 
             // there may be some exceptions on events
             // so if anything goes bad its ID won't be added on the successfullEvents

--- a/tests/CashierFastspringTest.php
+++ b/tests/CashierFastspringTest.php
@@ -26,12 +26,12 @@ class CashierFastspringTest extends TestCase
     public static function setUpBeforeClass()
     {
         if (file_exists(__DIR__.'/.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__);
+            $dotenv = \Dotenv\Dotenv::create(__DIR__);
             $dotenv->load();
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/FastspringTest.php
+++ b/tests/FastspringTest.php
@@ -20,12 +20,12 @@ class FastspringTest extends TestCase
     public static function setUpBeforeClass()
     {
         if (file_exists(__DIR__.'/.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__);
+            $dotenv = \Dotenv\Dotenv::create(__DIR__);
             $dotenv->load();
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         // prepare class for testing
         $mock = new MockHandler(array_fill(

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -18,12 +18,12 @@ class InvoiceTest extends TestCase
     public static function setUpBeforeClass()
     {
         if (file_exists(__DIR__.'/.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__);
+            $dotenv = \Dotenv\Dotenv::create(__DIR__);
             $dotenv->load();
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/ListenersTest.php
+++ b/tests/ListenersTest.php
@@ -20,12 +20,12 @@ class ListenersTest extends TestCase
     public static function setUpBeforeClass()
     {
         if (file_exists(__DIR__.'/.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__);
+            $dotenv = \Dotenv\Dotenv::create(__DIR__);
             $dotenv->load();
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -7,7 +7,7 @@ use Orchestra\Testbench\TestCase;
 
 class ServiceProviderTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/SubscriptionPeriodTest.php
+++ b/tests/SubscriptionPeriodTest.php
@@ -16,12 +16,12 @@ class SubscriptionPeriodTest extends TestCase
     public static function setUpBeforeClass()
     {
         if (file_exists(__DIR__.'/.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__);
+            $dotenv = \Dotenv\Dotenv::create(__DIR__);
             $dotenv->load();
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -20,12 +20,12 @@ class SubscriptionTest extends TestCase
     public static function setUpBeforeClass()
     {
         if (file_exists(__DIR__.'/.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__);
+            $dotenv = \Dotenv\Dotenv::create(__DIR__);
             $dotenv->load();
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Traits/Database.php
+++ b/tests/Traits/Database.php
@@ -17,7 +17,7 @@ trait Database
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Schema::drop('users');
         Schema::drop('subscriptions');

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -14,7 +14,7 @@ class WebhookControllerTest extends TestCase
     public static function setUpBeforeClass()
     {
         if (file_exists(__DIR__.'/.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__);
+            $dotenv = \Dotenv\Dotenv::create(__DIR__);
             $dotenv->load();
         }
     }

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -7,6 +7,7 @@ use Bgultekin\CashierFastspring\Tests\Fixtures\WebhookControllerTestStub;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 
 class WebhookControllerTest extends TestCase
@@ -182,11 +183,11 @@ class WebhookControllerTest extends TestCase
             // prepare category event class names like OrderAny
             $explodedType = explode('.', $mockEvent['type']);
             $category = array_shift($explodedType);
-            $categoryEvent = 'Bgultekin\CashierFastspring\Events\\'.studly_case($category).'Any';
+            $categoryEvent = 'Bgultekin\CashierFastspring\Events\\'.Str::studly($category).'Any';
 
             // prepare category event class names like activity
             $activity = str_replace('.', ' ', $mockEvent['type']);
-            $activityEvent = 'Bgultekin\CashierFastspring\Events\\'.studly_case($activity);
+            $activityEvent = 'Bgultekin\CashierFastspring\Events\\'.Str::studly($activity);
 
             $listenEvents = [
                 Events\Any::class,


### PR DESCRIPTION
> **UPDATE**: In addition, I have also had to upgrade `phpdotenv` and upgrading this and `carbon` were not as simple as this original PR once thought. As such, I have now written a more comprehensive PR which addresses all the changes across the various commits I have made.

# Migrating Carbon and Phpdotenv

There have been a number of implications for upgrading `carbon` and `phpdotenv`. The changes contained below as well as all the submissions to this PR address the upgrade so all runs smoothly, tests don't fail and upgrading is seamless.

## Upgrading Carbon

The change in `composer.json`–upgrading from `~1.0` to `v2.0`– is critical as `laravel/cashier v10.5.*` requires `nesbot/carbon ^2.0`. Without this upgrade, this package won't work on Laravel 5.8 and upwards.

`carbon 1.0` has also been deprecated so this change has no other option but to take place.

## Laravel deprecations

The `fire` method, which was deprecated in Laravel 5.4, of the `Illuminate\Events\Dispatcher` class in `\Http\Controllers\WebhookController.php` [has been removed](https://laravel.com/docs/5.8/upgrade#events). The fix is to use the `dispatch` method.

This event method now looks like this:

```php
Event::dispatch(
   new Events\Any(
       $event['id'],
       $event['type'],
       $event['live'],
       $event['processed'],
       $event['created'],
       $event['data']
   )
);
```

## Unit test failures

Running this command `vendor/bin/phpunit` produces a number of errors due to the upgrade of `carbon` and, more specifically, `phpdotenv` from version `2` to `3`. There have been a number of core changes and deprecations.

### phpunit.xml

This error has been resolved:

```console
Warning - The configuration file did not pass validation!
The following problems have been detected:

Line 12:
- Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.
```

### Declaration incompatibility

This issue has been addressed across multiple files where `setUp()` method was implemented:

```console
PHP Fatal error:  Declaration of Bgultekin\CashierFastspring\Tests\****Test::setUp() must be compatible with Orchestra\Testbench\TestCase::setUp()
```

The issue below was resolved in changes made to `Traits\Database.php`:

```console
PHP Fatal error:  Declaration of Bgultekin\CashierFastspring\Tests\Traits\Database::tearDown() must be compatible with Orchestra\Testbench\TestCase::tearDown()
```

### Dotenv constructor changes

The upgrade from version `2` to `3` of `phpdotenv` meant I had to replace many occurrences of `new Dotenv(...)` with `Dotenv::create(...)` since the new native constructor takes a Loader instance.

This meant that `$dotenv = new \Dotenv\Dotenv(__DIR__);` changed to `$dotenv = \Dotenv\Dotenv::create(__DIR__);`.

Notably, Issue [#306](https://github.com/vlucas/phpdotenv/pull/306) discusses and implements the `Loader::load()` and its callers now return an associative array of variables loaded with their values, rather than an array of raw lines from the environment file. This issue hasn't been tested yet in this set of submitted patch changes so I don't know what this outcome will have on the code.

## Additional code failures

With all the above changes implemented `phpunit` now runs successfully but there are 4 of the 70 tests that are failing. Fixing these are outside the scope of the PR.

```
$ vendor/bin/phpunit
PHPUnit 7.5.17 by Sebastian Bergmann and contributors.

Warning:       opcache.save_comments=0 set; annotations will not work
Error:         No code coverage driver is available

................................................................. 65 / 70 ( 92%)
.....                                                             70 / 70 (100%)

Time: 658 ms, Memory: 18.00 MB

OK (70 tests, 219 assertions)
```
